### PR TITLE
主题sunlight更新v1.0.1

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -20,7 +20,7 @@
     "reedtop/ReedDark@5c6e824b8e67d70301393419724dd1eb8a6b4f1a",
     "reedtop/ReedLight@d4332a2342a85ea92dda2de0ff5b24a8660faf05",
     "langzhou/spring-theme-for-siyuan@0fe8fde39e6810bdf90617a4d721d900e66950c9",
-    "VIWZ/Sunlight@8d0a5b358bebb0cece46dbbd0adb8abd858f8a25",
+    "VIWZ/Sunlight@ae76497c5c2715d41a48ba75900a0b875b9cbdc2",
     "langzhou/roam-like-theme@237a0464ab9df09e2d754c5a091810de4dd192a8",
     "langzhou/sea-theme-for-siyuan@113758fa044805e2e15d4d35294bb3a72945c0e2"
   ]


### PR DESCRIPTION
1、修改了拖动的阴影粗度
2、修改了标题的line- height,这样保证窗口变小时不会出现文字重叠的情况
3、修改了选中文字时的颜色，这样会更加淡雅
4、编辑器光标颜色引入主题色
5、列表左边添加一条实线
6、全部缩小为原来的大小，以便其他人自行调整。