### PR TITLE
新挂件 cover-drawio

### DIFF
--- a/widgets.json
+++ b/widgets.json
@@ -9,6 +9,7 @@
     "dicarne/sy-secret-block@86b6184e98a4a61321adfdf3ac6bf91318869354",
     "Achuan-2/siyuan-widget-clockpac@b06a74ede0c81f5ba7bd42c1f62fc0d10dd12b7d",
     "dicarne/sy-canvas@d7e95e2967131869d4d3c51e1d56abe8794176b3",
-    "bearxz/sy-excalidraw@055265c2ce3c35437b3b966c5548690aa862026e"
+    "bearxz/sy-excalidraw@055265c2ce3c35437b3b966c5548690aa862026e",
+    "macvip/cover-drawio@fd4cebabd76c61d5d3f2ac08eb6b009bf96476bf"
   ]
 }


### PR DESCRIPTION
配合思源笔记的 drawio 挂件 创建并显示 svg 格式的图片

## 主要功能
* 引导创建 draw.io 绘图文件
* 支持 svg 格式的绘图文件显示
* 全屏预览图片
* 手动刷新图片显示
* 调用浏览器，打开 drawio 挂件并编辑绘图文件
* 将 svg 格式图片转换为 png 格式，并下载
* 拷贝 svg 格式图片的资源链接到剪切板，方便以图片形式插入到笔记中
