### PR TITLE
Sofill-0.18 Release for 2210累计更新

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -23,7 +23,7 @@
     "OIREVASMAI/Oir-Dark@fe602ba22bc0fdae407053b8495c26c731ac3d3b",
     "YYHCOPPOLO/BluePrint-From-Tsundoku@12dd1ed668efc904dbfba37208609b67883cc768",
     "lanedu/Knowledge-Brain@e9b006c98fb6a2106b4f111e6b4790a4f78171fe",
-    "Soltus/winsay@de7602cc7e9573d46ccc9de553897afdf14416d5",
+    "Soltus/winsay@5d5cae2ab19f7ba7dd4c155148207df368b6a1e1",
     "TinkMingKing/PureSY@0bc4cbaf72c78bf4bb7ff6032bc01128107e82b7",
     "weihan-Chen/pureDark@53a7ddb9b02c2cdbbf990bc9b66b6f46df3b354b",
     "StarDustSheep/pink-room@f1dcb95ecdc26cdee2d9a624d849f3331315db86"


### PR DESCRIPTION
https://github.com/Hi-Windom/winsay/releases/tag/0.18

考虑到思源2.4.2变动较大，适配需要较长时间，因此适配2.4.2交由0.20或后续版本