### PR TITLE
更新主题，对原始的双链查看综合体验进行改进

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -29,6 +29,6 @@
     "StarDustSheep/pink-room@ebee10ab18fb3c79f13b1e6b22f25eecce491518",
     "Oltermare/Ori-Light-for-Mobile@82bdebf363aac91da15fb4d6bab1fad0eee282ad",
     "Oltermare/Ori-Dark-for-Mobile@d9c7dfd8a39990d25c828173e9c126976a10606f",
-    "Oltermare/Consistent@27b7e65d5a2a1d77783bbd73663e84826bff3d96"
+    "Oltermare/Consistent@94bb2517fb3291e331f8d4c55f4be54b8c4b7a9f"
   ]
 }


### PR DESCRIPTION
* [X] 面包屑改造
  * [X] 第一个的面包屑（文章标题）改成蓝色（包括标题，方便在多个面包屑时区分）
  * [X] 嵌入块、弹出窗、反链面板：其他面包屑去除文字，**鼠标放上去时展开**
* [x] 反链面板样式
  * [X] 多个结果用阴影划分
* [X] 弹出窗
  * [X] 多个结果用阴影划分
  * [X] 取消设置按钮
* [X] 标签面板
  * [X] 取消设置按钮

![弹出面包屑2.gif](https://s2.loli.net/2022/11/04/Hfpg46uqvwXkItV.gif)

![image.png](https://s2.loli.net/2022/11/04/Es78VXtQWuH4MlJ.png)