### PR TITLE
下架主题

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -11,8 +11,6 @@
     "UserZYF/blue-dog",
     "UFDXD/HBuilderX-Light",
     "lanedu/Knowledge-Brain",
-    "Hi-Windom/winsay",
-    "Hi-Windom/lili",
     "Soltus/BHQ-Mobile",
     "TinkMingKing/PureSY",
     "weihan-Chen/pureDark",


### PR DESCRIPTION
Sofill-和Sofill=主题缺乏维护，不再适用思源笔记，因此下架