### PR TITLE
update plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -159,6 +159,7 @@
     "shady2k/siyuan-inbox-telegram-plugin",
     "vanchKong/layout-plugin",
     "springtwr/siyuan-code-tabs",
-    "Juexe/siyuan-create-file-plugin"
+    "Juexe/siyuan-create-file-plugin",
+    "jzmanu/siyuan-icon-tools"
   ]
 }


### PR DESCRIPTION
The siyuan-title-icon-manager plugin is used to manage icons in the title bar. Currently supported functions are as follows:
- Support icon group selection, multiple selections, default selection.
- Support mouse "right-click" on the icon to randomly fill the icon.
- Modify the number of icon documents and outline linkage.