### PR TITLE
Add a theme with numbering and colored heading

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -36,6 +36,7 @@
     "mustakshif/Asri",
     "chenshinshi/blue-dog",
     "chenshinshi/BHQ-Mobile",
+    "handlI/SiYuanSimpleTheme",
     "lingfengyu-dreaming/siyuan-vscodelite-edit"
   ]
 }


### PR DESCRIPTION
添加一个主题：在官方样式的基础上，对标题进行自动编号和颜色渲染。
主题的链接：https://github.com/handlI/SiYuanSimpleTheme
