### PR TITLE
Add Macavity/siyuan-database-properties-panel

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -197,6 +197,7 @@
     "kuangdongksk/siyuan-access-controller",
     "lingfengyu-dreaming/siyuan-ttf-Alibaba_PuHui_Sans",
     "emlog/siyuan-to-emlog",
-    "Achuan-2/siyuan-plugin-formatPainter"
+    "Achuan-2/siyuan-plugin-formatPainter",
+    "Macavity/siyuan-database-properties-panel"
   ]
 }


### PR DESCRIPTION
Submitting Macavity/siyuan-database-properties-panel plugin for the bazaar.

* [x] The repository is public
* [x] Include the appropriate open source license file `LICENSE`
* [x] Does not involve infringing content, such as non-commercial font files
