### PR TITLE
add: 添加媒体播放器插件

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -221,6 +221,7 @@
     "zxkmm/siyuan_database_landscape_scrollbar",
     "wu1233456/quick-notes",
     "zxkmm/siyuan_doctree_fake_subfolder",
-    "zxkmm/siyuan_mobile_marketplace"
+    "zxkmm/siyuan_mobile_marketplace",
+    "mm-o/siyuan-media-player"
   ]
 }


### PR DESCRIPTION
# 添加思源媒体播放器插件

## 插件介绍
- 插件名称：思源媒体播放器
- 插件描述：一个思源笔记媒体播放器插件，支持多种媒体格式，提供丰富的播放功能。
- 仓库地址：https://github.com/mm-o/siyuan-media-player

## 功能特性
- 支持多种媒体格式播放
- 支持B站视频播放
- 提供丰富的播放控制功能

## 检查清单
- [x] 已测试插件功能
- [x] 代码遵循规范
- [x] 文档完善
