### PR TITLE
Submitting Macavity/siyuan-widget-database-block to the Marketplace

### DIFF
--- a/widgets.json
+++ b/widgets.json
@@ -38,6 +38,7 @@
     "Frankgbg/OneSentence",
     "linzhi66/widget-excel",
     "webceoboy/moredraw-widget-siyuan",
+    "Macavity/siyuan-widget-database-block",
     "samonysh/siyuan-pseudocode"
   ]
 }


### PR DESCRIPTION
Submitting Macavity/siyuan-widget-database-block to the Marketplace.

* [x] The repository is public
* [x] Include the appropriate open source license file `LICENSE`
* [x] Does not involve infringing content, such as non-commercial font files
