### PR TITLE
push showtime-siyuan

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -232,6 +232,7 @@
     "silent1189/siyuan-imageConverter",
     "Asianfleet/siyuan-plugin-aether",
     "Misuzu2027/syplugin-outlink-search",
-    "Achuan-2/siyuan-plugin-doctree-focus"
+    "Achuan-2/siyuan-plugin-doctree-focus",
+    "mcwz/showtime-siyuan"
   ]
 }


### PR DESCRIPTION
此插件可以显示块修改时间，对笔记正文无任何污染。当鼠标移到内容块上时，左侧会显示当前块的修改时间。