### PR TITLE
增加插件: SiYuan-paperless

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -254,6 +254,7 @@
     "ebAobS/roaming-mode-incremental-reading",
     "L1cardo/siyuan-plugin-material-icon",
     "TangQi001/siyuan-plugin-create-doc",
-    "hogmoff/siyuan-plugin-templater"
+    "hogmoff/siyuan-plugin-templater",
+    "Jasaxion/siyuan-paperless"
   ]
 }


### PR DESCRIPTION
一个简单的插件，将 SiYuan 笔记连接到个人 PaperLess 文档库，并上传思源文档资源到 PaperLess 服务，Paperless 自动识别和标签归档。

If you are submitting a new bazaar package for the first time, please confirm the following information.

* [x] The repository is public
* [x] Include the appropriate open source license file `LICENSE`
* [x] Does not involve infringing content, such as non-commercial font files
