### PR TITLE
Add jeasionr-ui/openlist plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -259,6 +259,7 @@
     "Jasaxion/siyuan-paperless",
     "Achuan-2/siyuan-plugin-task-note-management",
     "idea-zone/mini-favorites",
-    "luqin2007/siyuan-reference-code-block-plugin"
+    "luqin2007/siyuan-reference-code-block-plugin",
+    "jeasionr-ui/openlist"
   ]
 }


### PR DESCRIPTION
AList 文件浏览器插件 为思源笔记用户提供了完整的文件管理解决方案。通过深度集成 AList(OpenList) 文件管理器，您可以：

🗂️ 在思源笔记侧边栏中直接浏览和管理文件
📎 将 AList 文件无缝嵌入到笔记内容中
🔄 实现笔记与文件管理的一体化体验
🌐 支持本地和远程文件服务器访问