### PR TITLE
Add syspell plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -278,6 +278,7 @@
     "zhongjiahao-M/shortcut-color-plugin",
     "zxbdzh/siyuan-plugin-export-s3-markdown",
     "hausen1012/siyuan-plugin-pic-bed-manager",
-    "lovexmm521/siyuan-plugin-QianQiankuai"
+    "lovexmm521/siyuan-plugin-QianQiankuai",
+    "massivebox/syspell"
   ]
 }


### PR DESCRIPTION
If you are submitting a new bazaar package for the first time, please confirm the following information.

* [x] The repository is public
* [x] Include the appropriate open source license file `LICENSE`
* [x] Does not involve infringing content, such as non-commercial font files

This pull request adds the SySpell plugin, a spelling and grammar checker for SiYuan, like Grammarly but completely free and open source.