### PR TITLE
feat(plugins): add clouder0/siyuan-typst-plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -280,6 +280,7 @@
     "hausen1012/siyuan-plugin-pic-bed-manager",
     "lovexmm521/siyuan-plugin-QianQiankuai",
     "massivebox/syspell",
-    "KilluaYZ/siyuan-plugin-latest-notes"
+    "KilluaYZ/siyuan-plugin-latest-notes",
+    "clouder0/siyuan-typst-plugin"
   ]
 }


### PR DESCRIPTION
If you are submitting a new bazaar package for the first time, please confirm the following information.

* [x] The repository is public
* [x] Include the appropriate open source license file `LICENSE`
* [x] Does not involve infringing content, such as non-commercial font files

This plugin adds experimental Typst Math Rendering support for SiYuan Note.
