### PR TITLE
Add Plugin abc202306/siyuan-adaptive-expander

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -286,6 +286,7 @@
     "Jasaxion/siyuan-arxiv-paper-download",
     "shijianjs/siyuan-plugin-markmap-view",
     "zongqir/key-info-navigator",
-    "zongqir/highlight_assistant"
+    "zongqir/highlight_assistant",
+    "abc202306/siyuan-adaptive-expander"
   ]
 }


### PR DESCRIPTION
Add Plugin SiYuan Adaptive Expander: https://github.com/abc202306/siyuan-adaptive-expander

## Description

思源插件：自适应展开列表块或章节块等可折叠块，当对可折叠块进行聚焦和链接预览时 | This plugin for the Siyuan Note software has the following feature: it adaptively expands collapsible blocks such as list blocks or section blocks when those blocks are focused on or previewed via links.


<img width="160" height="160" alt="icon" src="https://github.com/user-attachments/assets/d8ff306e-4b00-4435-9fbb-f477b77fa515" />
