### PR TITLE
Add TCOTC/inline-elements

### DIFF
--- a/widgets.json
+++ b/widgets.json
@@ -45,6 +45,7 @@
     "prog4food/widget-excalidraw-2025",
     "tangshangkui/encrypt-excel",
     "Jasaxion/siyuan-code-judge",
-    "WACrown/widget-drawio-watermelonhub"
+    "WACrown/widget-drawio-watermelonhub",
+    "TCOTC/inline-elements"
   ]
 }


### PR DESCRIPTION
一个汇总文档行级元素的挂件，用于替代 https://github.com/hqweay/widget-inline-extractor