### PR TITLE
Remove fansOnly/aivc-plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -293,7 +293,6 @@
     "zongqir/siyuan-flashcard-assistant",
     "abc202306/siyuan-adaptive-expander",
     "ebAobS/mymind",
-    "fansOnly/aivc-plugin",
     "QYLexpired/QYL-ImgMask",
     "QYLexpired/QYL-ListView",
     "asdfcyt/sy-quickswitch-release",


### PR DESCRIPTION
Removed 'fansOnly/aivc-plugin' from the plugins list.

If you are submitting a new bazaar package for the first time, please confirm the following information.

* [ ] The repository is public
* [ ] Include the appropriate open source license file `LICENSE`
* [ ] Does not involve infringing content, such as non-commercial font files
