### PR TITLE
Add Macavity/siyuan-rag-assistant

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -211,6 +211,7 @@
     "Achuan-2/siyuan-plugin-formatPainter",
     "Macavity/siyuan-database-properties-panel",
     "Macavity/siyuan-tasks",
+    "Macavity/siyuan-rag-assistant",
     "Achuan-2/siyuan-plugin-imgAddLink",
     "SteelDrEgg/siyuan-graph",
     "zt8989/siyuan-drawio-plugin",


### PR DESCRIPTION
As this is a new package, I am confirming:

* [x] The repository is public
* [x] Include the appropriate open source license file `MIT`
* [x] Does not involve infringing content, such as non-commercial font files
