### PR TITLE
Add notehelper plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -296,6 +296,7 @@
     "rio-csharp/next-page-button",
     "ZeroHawkeye/siyuan-share",
     "QYLexpired/Asri-enhance",
-    "langfeld/code-line-highlighter"
+    "langfeld/code-line-highlighter",
+    "notesynchelper/siyuan-notehelper"
   ]
 }


### PR DESCRIPTION
Add notesynchelper/siyuan-notehelper plugin to the bazaar.

## Plugin Info
- Name: Note Sync Helper (笔记同步助手)
- Repo: https://github.com/notesynchelper/siyuan-notehelper
- Version: 1.0.0
- Description: Sync notes and articles from WeChat to SiYuan, with support for images, chat messages, and custom templates

## Checklist
- [x] Release v1.0.0 created with package.zip
- [x] Plugin.json properly configured
- [x] README files in both English and Chinese
- [x] Preview image and icon included