### PR TITLE
Add notesynchelper/siyuan-notehelper

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -296,6 +296,7 @@
     "rio-csharp/next-page-button",
     "ZeroHawkeye/siyuan-share",
     "QYLexpired/Asri-enhance",
-    "langfeld/code-line-highlighter"
+    "langfeld/code-line-highlighter",
+    "notesynchelper/siyuan-notehelper"
   ]
 }


### PR DESCRIPTION
Add notesynchelper/siyuan-notehelper plugin to the bazaar.

## Plugin Info
- **Name**: Note Sync Helper (笔记同步助手)
- **Repo**: https://github.com/notesynchelper/siyuan-notehelper
- **Author**: notesynchelper
- **Version**: 1.0.0
- **Description**: Sync notes and articles from WeChat to SiYuan, with support for images, chat messages, and custom templates

## Checklist

### Required Attributes in plugin.json
- [x] `name` attribute exists
- [x] Is a valid name: `notehelper`
- [x] Not conflict with other plugin name (verified in bazaar)

### Package Requirements
- [x] Release v1.0.0 created with package.zip
- [x] plugin.json properly configured with all required fields
- [x] README files in both English (README.md) and Chinese (README_zh_CN.md)
- [x] Preview image (preview.png - 1024x768) included
- [x] Icon (icon.png - 160x160) included

### Metadata Verification
- [x] `author`: notesynchelper
- [x] `url`: https://github.com/notesynchelper/siyuan-notehelper
- [x] `version`: 1.0.0 (follows semver)
- [x] `minAppVersion`: 3.3.0
- [x] `displayName`: English and Chinese
- [x] `description`: English and Chinese
- [x] `readme`: English and Chinese
- [x] `backends`: all platforms
- [x] `frontends`: all platforms
- [x] `keywords`: relevant search keywords included