### PR TITLE
Remove lovexmm521/siyuan-plugin-QianQiankuai

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -267,7 +267,6 @@
     "zhongjiahao-M/shortcut-color-plugin",
     "zxbdzh/siyuan-plugin-export-s3-markdown",
     "hausen1012/siyuan-plugin-pic-bed-manager",
-    "lovexmm521/siyuan-plugin-QianQiankuai",
     "massivebox/syspell",
     "KilluaYZ/siyuan-plugin-latest-notes",
     "clouder0/siyuan-typst-plugin",


### PR DESCRIPTION
Removed 'lovexmm521/siyuan-plugin-QianQiankuai' from the plugins list.

If you are submitting a new bazaar package for the first time, please confirm the following information.

* [ ] The repository is public
* [ ] Include the appropriate open source license file `LICENSE`
* [ ] Does not involve infringing content, such as non-commercial font files
