### PR TITLE
Add wish5115/siyuan-image-studio

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -303,6 +303,7 @@
     "mm-o/siyuan-sireader",
     "snail-vs/sy-plugin-image-tools",
     "Achuan-2/siyuan-plugin-simplemindmap",
-    "Achuan-2/siyuan-plugin-drawnix"
+    "Achuan-2/siyuan-plugin-drawnix",
+    "wish5115/siyuan-image-studio"
   ]
 }


### PR DESCRIPTION
思源图片编辑器是一款为思源笔记设计的轻量级图片编辑插件，让你可以直接在笔记中对图片进行标注、涂鸦、裁剪、翻转等操作，无需借助外部工具。

![preview.png](https://fastly.jsdelivr.net/gh/wish5115/siyuan-image-studio@main/preview.png)

If you are submitting a new bazaar package for the first time, please confirm the following information.

* [x] The repository is public
* [x] Include the appropriate open source license file `LICENSE`
* [x] Does not involve infringing content, such as non-commercial font files
