### PR TITLE
Add concurrency limits to the Stage workflow

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 * * * *'
 
+concurrency:
+  group: stage
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
siyuan-note/bazaar#1684

https://docs.github.com/zh/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

根据文档，这样写应该是生效了，所有stage actions归在stage组下，然后这个组只能有一个运行中，后续运行会pending，再次运行工作流会取代pending（？详见文档

但限制并发数量应该是做到了，这个也是用 VSCode 的 GitHub Actions 扩展补全出来的，应该不含语法错误（需要再次检查
