### PR TITLE
Add c00llin/siyuan-daily-nav

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -323,7 +323,7 @@
     "royc01/pinch",
     "HaoCeans/siyuan-toolbar-customizer",
     "KPRepos/audio2text_siyuan_plugin",
-    "c00llin/siyuan-daily-nav"
+    "c00llin/siyuan-daily-nav",
     "5kyfkr/siyuan-plugin-docktomato",
     "gnakilgnoh/siyuan-task-planner",
     "liao-zh/siyuan-inbox-transfer"


### PR DESCRIPTION
Simple plugin that adds 2 commands to back/forward daily notes by date and created daily notes when they don't exist.