### PR TITLE
Add byssssss/siyuan-caldav-sync

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -364,3 +364,4 @@ famotime/siyuan-network-lens
 famotime/siyuan-image-quickedit
 bytemain/siyuan-plugin-settings-sync
 yongnianliu/claude-to-siyuan
+byssssss/siyuan-caldav-sync


### PR DESCRIPTION

## 新增插件：siyuan-caldav-sync

### 插件名称
CalDAV 同步

### 插件简介
为思源笔记补上日历面板和日历提醒——数据在思源数据库，提醒通过 CalDAV 调用系统日历

### 解决的问题
思源没有日历面板，事件只能以表格行存在，无法直观查看日程；也没有提醒，到时间不会响。本插件同时解决这两个问题。

### 功能亮点
- **日历面板**：月/日/年三视图，面板内直接新建/编辑事件和任务，无需在数据库表格中翻找
- **双向同步**：思源属性表 ↔ CalDAV 日历，改任一端自动同步到另一端
- **系统级提醒**：通过 CalDAV 同步到手机/电脑日历应用，调用系统通知，到时间真正会响
- **数据在思源**：所有数据存储在思源属性表中，CalDAV 只是同步通道，数据主权始终在思源
- **任务管理**：优先级·进度·勾选框三维度，进度联动日期自动填充，到达时间自动推进
- **多账户**：同时接入多个 CalDAV 日历（个人/工作/家庭）
- **熔断保护**：连续错误自动暂停，思源数据为空时拒绝同步，防止误删

### 仓库地址
https://github.com/byssssss/siyuan-caldav-sync

### Release
https://github.com/byssssss/siyuan-caldav-sync/releases/tag/0.2.0