### PR TITLE
Update fujingzhai/siyuan-unified-search repository path

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -308,6 +308,7 @@
     "wish5115/siyuan-image-studio",
     "Eatin/click2fill",
     "fanyao1983/siyuan-experience-enhancer",
-    "Achuan-2/siyuan-plugin-imgReEditor"
+    "Achuan-2/siyuan-plugin-imgReEditor",
+    "youxia2025-wq/siyuan-unified-search"
   ]
 }

--- a/plugins.json
+++ b/plugins.json
@@ -309,6 +309,6 @@
     "Eatin/click2fill",
     "fanyao1983/siyuan-experience-enhancer",
     "Achuan-2/siyuan-plugin-imgReEditor",
-    "youxia2025-wq/siyuan-unified-search"
+    "fujingzhai/siyuan-unified-search"
   ]
 }


### PR DESCRIPTION
This updates the unified search plugin repository entry from the old redirected path to the current canonical repository:\n\n- from: \n- to: \n\nA new release has been published at .