### PR TITLE
Add mm-o/siyuan-cloud

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -387,3 +387,4 @@ wj1002/plugin-ChronicleX-vite-svelte
 Mangteng1994/siyuan-plugin-gitee-pages
 fujingzhai/claude-note
 famotime/siyuan-sketch-note
+mm-o/siyuan-cloud


### PR DESCRIPTION
## Summary

Add `mm-o/siyuan-cloud` to the SiYuan community bazaar plugin list.

## Plugin release

- Repository: https://github.com/mm-o/siyuan-cloud
- Latest release: https://github.com/mm-o/siyuan-cloud/releases/tag/v0.3.1
- Release asset: `package.zip`
- Required SiYuan version: `3.7.0` or later, because this plugin depends on kernel plugin HTTP routes and `body.proxy` streaming proxy support.
- Preview image fix: `preview.png` was regenerated from the provided WebP as a real PNG, verified as 1024x768, and repackaged in `v0.3.1`.

## Reviewer verification notes

Recommended quick test path:

1. Use SiYuan 3.7.0 or later.
2. Open the plugin Dock panel, go to Mounts, and add a storage. `123Pan` is recommended for the first playback test because its playback path is simpler.
3. Open the top bar file manager and browse mounted files.
4. Right-click a media file, choose Copy Link, then paste the generated Markdown link into a SiYuan document for preview/playback.

Baidu Netdisk notes:

- For video playback, set the Baidu driver download API to `crack` or `crack_video`; ordinary official links may not be playable for every account/file.
- Disable network/system proxies during playback verification. Baidu links are sensitive to egress IP changes and may fail to preview or play through a proxy.
- Baidu playback depends on the streaming proxy capability from SiYuan PR #17748; without it, Baidu Range playback may fail even when listing and link resolution work.

The same notes are included in `README.md` and `README_zh_CN.md` in the plugin repository.

## Local checks

- `pnpm test:kernel`: passed
- `pnpm build`: passed
- `preview.png`: verified as PNG, 1024x768, 113,387 bytes
- `package.zip`: regenerated for `v0.3.1` and contains the fixed `preview.png`
