### PR TITLE
Add Handao-dao/siyuan-hd-image-export

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -387,3 +387,4 @@ wj1002/plugin-ChronicleX-vite-svelte
 Mangteng1994/siyuan-plugin-gitee-pages
 fujingzhai/claude-note
 famotime/siyuan-sketch-note
+Handao-dao/siyuan-hd-image-export


### PR DESCRIPTION
Add `Handao-dao/siyuan-hd-image-export` to the SiYuan community bazaar plugin list.\n\nThe plugin exports the current document as high-resolution paged PNG images for readable sharing. Release: https://github.com/Handao-dao/siyuan-hd-image-export/releases/tag/v0.1.0