### PR TITLE
Add zhuxiucai/siyuandateprefix

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -388,3 +388,4 @@ Mangteng1994/siyuan-plugin-gitee-pages
 fujingzhai/claude-note
 famotime/siyuan-sketch-note
 mm-o/siyuan-cloud
+zhuxiucai/siyuandateprefix


### PR DESCRIPTION
这个插件是用来根据思源内部 updated 字段刷新文档标题 YYMMDD 前缀，并永远跳过目录型文档。

If you are submitting a new bazaar package for the first time, please confirm the following information.

* [ x ] The repository is public
* [ x ] Include the appropriate open source license file `LICENSE`
* [ x ] Does not involve infringing content, such as non-commercial font files

If your marketplace package is closed-source, please grant @TCOTC, @88250, and @Vanessa219 access to the source code so that we can complete the review.
