### PR TITLE
Add pili8/siyuan-toggl-sync

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -384,3 +384,4 @@ fujingzhai/claude-note
 famotime/siyuan-sketch-note
 Handao-dao/siyuan-hd-image-export
 mm-o/siyuan-cloud
+pili8/siyuan-toggl-sync


### PR DESCRIPTION
Add Toggl Sync plugin - sync Toggl time entries to SiYuan database.

Plugin repo: https://github.com/pili8/siyuan-toggl-sync
Release: https://github.com/pili8/siyuan-toggl-sync/releases/tag/v0.1.0