### PR TITLE
Delist Han-Orz/siyuan-zen

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -216,7 +216,6 @@ mm-o/siyuan-media-player
 DD3Boh/url-bookmark-notes
 DD3Boh/better-block-styling
 wu1233456/siyuan-plugin-sidebar-widget
-Han-Orz/siyuan-zen
 onemorework/SiyuanWechatSync
 zxkmm/siyuan_rmv_btn_classic
 silent1189/siyuan-imageConverter


### PR DESCRIPTION
﻿Removing the old entry so the stale stage orphan gets garbage-collected by the next stage.yml run.

Background: issue #4 requested the plugin.json `name` match the repo name. The author renamed `ZenType` to `siyuan-zen` in v2.0.0, but bazaar stage "name must be identical to current stage" rule rejected every release since, silently freezing the listing at v1.0.6 (last updated 2025-02-09).

Will re-add as `Han-Orz/zenType` in a follow-up PR after renaming the GitHub repo, once this orphan is cleared.