### PR TITLE
Add lisontowind/siyuan-footnote-jumper

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -412,3 +412,4 @@ fujingzhai/siyuan-inbox-plus
 fujingzhai/schedule-block
 alone-tree/siyuan-bridge
 Genwaygenway/siyuan-folder-lock
+lisontowind/siyuan-footnote-jumper


### PR DESCRIPTION
Footnote Jumper is a SiYuan plugin for Markdown-style footnotes.

It displays references such as [^1] as clickable links without modifying note data. Clicking a reference jumps to the matching [^1]: definition, and hovering shows the footnote content.

Repository: https://github.com/lisontowind/siyuan-footnote-jumper
Release: https://github.com/lisontowind/siyuan-footnote-jumper/releases/tag/v0.1.2
Package: https://github.com/lisontowind/siyuan-footnote-jumper/releases/download/v0.1.2/package.zip