### PR TITLE
Add maoruibin/siyuan-inbox-sync

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -384,3 +384,4 @@ fujingzhai/claude-note
 famotime/siyuan-sketch-note
 Handao-dao/siyuan-hd-image-export
 mm-o/siyuan-cloud
+maoruibin/siyuan-inbox-sync


### PR DESCRIPTION
## 新增插件

- **owner/repo**: `maoruibin/siyuan-inbox-sync`
- **displayName**: inBox Sync / inBox 同步
- **description**: 把 inBox 云端笔记（WebDAV/S3）单向同步到思源笔记

## Release

- v0.1.0: https://github.com/maoruibin/siyuan-inbox-sync/releases/tag/v0.1.0
- package.zip: https://github.com/maoruibin/siyuan-inbox-sync/releases/download/v0.1.0/package.zip

## 已自检

- [x] plugin.json 必填字段齐全（name/author/url/version/minAppVersion/backends/frontends/displayName/description/readme/icon）
- [x] icon.png 160×160 / preview.png 1024×768
- [x] package.zip 内含 index.js / plugin.json / i18n/ / icon.png / preview.png / README.md / LICENSE
- [x] 仓库公开可访问
- [x] Release v0.1.0 已发布，package.zip 作为 asset 可下载