### PR TITLE
Delist suka233/siyuan-keep-incremental-learning-plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -157,7 +157,6 @@ zxkmm/siyuan_leave_to_lock
 zxkmm/siyuan_marketplace_blacklist
 zxkmm/siyuan_doctree_compress
 muhanstudio/siyuan-plugin-embedding-html
-suka233/siyuan-keep-incremental-learning-plugin
 syh19/siyuan-plugin-task-list
 zxkmm/siyuan_main_window_modification
 tengfei-xy/siyuan-plugin-share-system


### PR DESCRIPTION
## Summary
- Remove `suka233/siyuan-keep-incremental-learning-plugin` from `plugins.txt`.

## Notes
- `stage/plugins.json` is generated by the Stage workflow after merge, so this PR leaves it unchanged.