### PR TITLE
Add Mangteng1994/siyuan-sishare

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -380,6 +380,7 @@ Mangteng1994/siyuan-xunzhang
 khnsojina-arch/siyuan-time-block-calendar
 wj1002/plugin-ChronicleX-vite-svelte
 Mangteng1994/siyuan-plugin-gitee-pages
+Mangteng1994/siyuan-sishare
 fujingzhai/claude-note
 famotime/siyuan-sketch-note
 Handao-dao/siyuan-hd-image-export


### PR DESCRIPTION
## Summary

- Add `Mangteng1994/siyuan-sishare` to the community plugin list.
- The plugin publishes SiYuan documents as static HTML directly to user-controlled S3 storage through `siyuan-cloud`.
- Unlike the Pages-based variant, it does not require a local Git repository.

## Release

- Latest release: `v0.3.2`
- `package.zip` is attached to the release.
- The repository includes `plugin.json`, `README.md`, a 160×160 `icon.png`, and a privacy-redacted 1024×768 `preview.png`.
- Public history was rewritten so historical `preview.png` references use the redacted image; `v0.3.0` was removed.

## Validation

- TypeScript type check passed.
- Production build and bundle syntax check passed.
- Release asset, version metadata, image dimensions, required files, and rewritten public references were verified.
