### PR TITLE
Add theme houm01/siyuan-theme-stillmark

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -48,3 +48,4 @@ alensiljak/alens-black-theme
 JeffZhA0/free-theme
 yck99/onelight-siyuan
 QYLexpired/Neo
+houm01/siyuan-theme-stillmark

--- a/themes.txt
+++ b/themes.txt
@@ -47,5 +47,5 @@ hongster/dracula-siyuan-theme
 alensiljak/alens-black-theme
 JeffZhA0/free-theme
 yck99/onelight-siyuan
-QYLexpired/Neo
 houm01/siyuan-theme-stillmark
+QYLexpired/Neo


### PR DESCRIPTION
Submit Stillmark / 静痕, a quiet white-first SiYuan theme with matched light and dark modes, refined inline code, code blocks, syntax highlighting, and block references.

- Repository: https://github.com/houm01/siyuan-theme-stillmark
- Release: https://github.com/houm01/siyuan-theme-stillmark/releases/tag/v0.1.0

If you are submitting a new bazaar package for the first time, please confirm the following information.

* [x] The repository is public
* [x] Include the appropriate open source license file `LICENSE`
* [x] Does not involve infringing content, such as non-commercial font files
