### PR TITLE
Add houm01/stillmark-workbench

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -414,5 +414,5 @@ alone-tree/siyuan-bridge
 Genwaygenway/siyuan-folder-lock
 lisontowind/siyuan-footnote-jumper
 alvisliu818/siyuan-plugin-browser
-alvisliu818/siyuan-virtual-tree
 houm01/stillmark-workbench
+alvisliu818/siyuan-virtual-tree

--- a/plugins.txt
+++ b/plugins.txt
@@ -415,3 +415,4 @@ Genwaygenway/siyuan-folder-lock
 lisontowind/siyuan-footnote-jumper
 alvisliu818/siyuan-plugin-browser
 alvisliu818/siyuan-virtual-tree
+houm01/stillmark-workbench


### PR DESCRIPTION
## Summary

Add `houm01/stillmark-workbench` to the SiYuan community marketplace plugin list.

Stillmark Workbench provides compact semantic block roles for notes, tips, warnings, important content, and muted content.

## Release

- Repository: https://github.com/houm01/stillmark-workbench
- Latest release: https://github.com/houm01/stillmark-workbench/releases/tag/v0.1.0
- Release asset: `package.zip`
- Minimum SiYuan version: 3.7.0

## Validation

- `pnpm check`
- `git diff --check`
- Verified `package.zip` integrity and required files
- Verified `icon.png` is 160x160 and `preview.png` is 1024x768
- Verified semantic role set, readback, clear, and cleanup against a disposable test notebook

## Checklist

- [x] The repository is public
- [x] The repository includes an MIT `LICENSE`
- [x] The package does not include infringing content or non-commercial font files
