### PR TITLE
Delist fujingzhai/siyuan-unified-search

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -301,7 +301,6 @@ wish5115/siyuan-image-studio
 Eatin/click2fill
 fanyao1983/siyuan-experience-enhancer
 Achuan-2/siyuan-plugin-imgReEditor
-fujingzhai/siyuan-unified-search
 loonghfut/siyuan-steve-tldraw
 BryceWG/siyuan-web-fetch
 b8l8u8e8/siyuan-plugin-lock


### PR DESCRIPTION
### 申请下架插件 / Delist Package

**插件名称 / Package Name**: `fujingzhai/siyuan-unified-search` (繁简体通用检索)

**下架原因 / Reason**:
该插件的繁简体通用检索功能已由作者提交 PR [siyuan-note/siyuan#17846](https://github.com/siyuan-note/siyuan/pull/17846) 成功内置于思源笔记本体内核中。插件已完成历史使命，故申请从集市下架。