### PR TITLE
Add tianxia704/siyuan-plugin-drawer

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -417,3 +417,4 @@ alvisliu818/siyuan-plugin-browser
 houm01/stillmark-workbench
 alvisliu818/siyuan-virtual-tree
 DilyarEziz/siyuan-plugin-asset-management
+tianxia704/siyuan-plugin-drawer


### PR DESCRIPTION
## Add plugin: siyuan-plugin-drawer

* Repo: https://github.com/tianxia704/siyuan-plugin-drawer
* Release: https://github.com/tianxia704/siyuan-plugin-drawer/releases/tag/v0.3.0 (with package.zip)
* Name: Plugin Drawer / 插件抽屉
* Description: Collects scattered third-party plugin controls into one top-bar entry and a native right-side plugin center.

Checklist:
- [x] plugin.json with name/author/url/version/minAppVersion/displayName/description/readme
- [x] icon.png (160x160), preview.png (1024x768)
- [x] README.md and README.zh_CN.md
- [x] i18n (en_US, zh_CN)
- [x] Release v0.3.0 with package.zip asset
