### PR TITLE
Add tianxia704/siyuan-plugin-left-shortcuts

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -417,3 +417,4 @@ alvisliu818/siyuan-plugin-browser
 houm01/stillmark-workbench
 alvisliu818/siyuan-virtual-tree
 DilyarEziz/siyuan-plugin-asset-management
+tianxia704/siyuan-plugin-left-shortcuts


### PR DESCRIPTION
## Add plugin: siyuan-plugin-left-shortcuts

* Repo: https://github.com/tianxia704/siyuan-plugin-left-shortcuts
* Release: https://github.com/tianxia704/siyuan-plugin-left-shortcuts/releases/tag/v0.1.1 (with package.zip)
* Name: 左侧快捷入口 / Left Shortcuts
* Description: Add independent Marketplace and Settings shortcuts to the bottom of SiYuan's left sidebar. Does not hide or replace the original entries.

Checklist:
- [x] plugin.json with name/author/url/version/minAppVersion/displayName/description/readme
- [x] icon.png (160x160), preview.png (1024x768)
- [x] README.md and README.zh_CN.md (Chinese-only listing)
- [x] i18n (en_US, zh_CN)
- [x] Release v0.1.1 with package.zip asset
