### PR TITLE
Add Han-Orz/zenType

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -421,3 +421,4 @@ DilyarEziz/siyuan-plugin-asset-management
 tianxia704/siyuan-plugin-left-shortcuts
 tianxia704/siyuan-plugin-drawer
 mwolfinspace/siyuan-dictionary
+Han-Orz/zenType


### PR DESCRIPTION
Add the renamed zenType plugin.

- Repository: https://github.com/Han-Orz/zenType
- Current release: v2.6.4
- plugin.json name: zenType
- The previous Han-Orz/siyuan-zen path was removed in #1894.

请确认以下信息：

1. 不涉及侵权内容，例如无商用授权的字体
2. 如果集市包是闭源的，请创建一个包含集市包完整源代码的私有 GitHub 仓库，并授予 @TCOTC、@88250 和 @Vanessa219 仓库访问权限，以便我们完成审核

Please confirm the following information:

1. Does not involve infringing content, such as fonts without a commercial-use license
2. If the marketplace package is closed-source, please create a private GitHub repository containing the complete source code of the marketplace package, and grant @TCOTC, @88250, and @Vanessa219 repository access so that we can complete the review

确认：

1. 本插件以 MIT License 开源发布。当前仓库未包含字体文件或其他已知未经商业授权的第三方资源；图标和预览资源为项目自有资源。我们未发现侵权内容。

2. zenType 是公开源码项目，完整源代码位于：https://github.com/Han-Orz/zenType。集市包由该公开仓库构建，并非闭源包，因此无需创建私有审核仓库或额外授予仓库访问权限。