### PR TITLE
Add acornyio/siyuan-note-sync

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -424,3 +424,4 @@ tianxia704/siyuan-plugin-left-shortcuts
 tianxia704/siyuan-plugin-drawer
 mwolfinspace/siyuan-dictionary
 Han-Orz/zenType
+acornyio/siyuan-note-sync


### PR DESCRIPTION
Add plugin `acornyio/siyuan-note-sync` (Acorny Sync / Acorny 高亮同步).

将 Acorny 的高亮单向同步进思源笔记：一个 source 对应一篇文档，用块自定义属性
（`custom-acorny-source-id` / `custom-acorny-id`）做去重，不覆盖用户在文档里的编辑。

- Repo: https://github.com/acornyio/siyuan-note-sync
- Latest Release: v1.1.0（含 `package.zip`）
- `minAppVersion`: 3.7.0，`frontends: ["all"]`

Checklist:

- [x] 仅新增 1 个包，未夹带其它改动
- [x] `plugins.txt` 新增一行 `owner/repo`，无多余逗号或空行
- [x] Latest Release 已发布并附带 `package.zip`
- [x] `package.zip` 包根含 `icon.png`(13.0 KB) / `preview.png`(12.2 KB) / `README.md` / `README.zh-CN.md` / `plugin.json`
- [x] `plugin.json` 的 `name` / `author` / `url` 与仓库一致，无未知字段
