### PR TITLE
Add itdh/siyuan-plugin-key-buddy

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -425,4 +425,5 @@ tianxia704/siyuan-plugin-drawer
 mwolfinspace/siyuan-dictionary
 Han-Orz/zenType
 acornyio/siyuan-note-sync
+itdh/siyuan-plugin-key-buddy
 QMike0/siyuan-plugin-page-search


### PR DESCRIPTION
# Summary
- Add itdh/siyuan-plugin-key-buddy to the community plugin list.
- The plugin is a local-first password manager plugin for SiYuan. It manages KDBX password vaults in your own SiYuan storage environment, without uploading vault data to a third-party service.
# Release
- Latest release: v0.1.0
- package.zip is attached to the release.
- The repository includes plugin.json, README.md, a 160×160 icon.png, and a 1024×768 preview.png.
# Validation
- TypeScript type check passed.
- Production build and bundle syntax check passed.
- Release asset, version metadata, image dimensions, required files, and rewritten public references were verified.