### PR TITLE
Add shangwuqinu/siyuan-block-meta-info

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -433,3 +433,4 @@ famotime/siyuan-query-builder
 dyzlog/SiYuan-code-block-beautify
 kxx/siyuan-insight-dashboard
 Sirin-Schariac/siyuan-cf-imgbed
+shangwuqinu/siyuan-block-meta-info


### PR DESCRIPTION
新增插件：`shangwuqinu/siyuan-block-meta-info`

首个版本：[v0.1.0](https://github.com/shangwuqinu/siyuan-block-meta-info/releases/tag/v0.1.0)

- [x] 不涉及侵权内容，例如无商用授权的字体
- [x] 插件完整源代码已公开在插件仓库中

- [x] Does not involve infringing content, such as fonts without a commercial-use license
- [x] The complete source code is publicly available in the plugin repository