### PR TITLE
Add HibernalGlow/siyuan-damophus

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -436,3 +436,4 @@ Sirin-Schariac/siyuan-cf-imgbed
 shangwuqinu/siyuan-block-meta-info
 Husense6/oh-my-siyuan
 Glaube-TY/siyuan-gesture-flow
+HibernalGlow/siyuan-damophus


### PR DESCRIPTION
## Package

Add HibernalGlow/siyuan-damophus to the SiYuan plugin bazaar.

- Latest release: https://github.com/HibernalGlow/siyuan-damophus/releases/tag/0.0.2
- Release asset: package.zip
- Metadata: plugin.json declares version 0.0.2 and the repository URL.

This PR changes only one plugin-list entry, per the bazaar contribution rules.