### PR TITLE
Add maoruibin/siyuan-inbox-sync

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -438,3 +438,4 @@ shangwuqinu/siyuan-block-meta-info
 Husense6/oh-my-siyuan
 Glaube-TY/siyuan-gesture-flow
 HibernalGlow/siyuan-damophus
+maoruibin/siyuan-inbox-sync


### PR DESCRIPTION
## 新增插件

- **name**: `siyuan-inbox-sync`
- **repo**: `maoruibin/siyuan-inbox-sync`
- **displayName**: inBox Sync / inBox 同步

## 简介

把 [inBox](https://inbox.gudong.site) 笔记单向同步到思源笔记的插件。支持 WebDAV / S3 兼容存储,增量同步、资源(图片/录音/附件)、批注、盒子分文件夹。

inBox 是"收集箱",编辑和删除交给桌面端做。插件只读云端,不在思源里修改云端数据,与同名的 Obsidian 插件共用同一套同步协议。

## 自检清单

- [x] 仓库名与 `plugin.json` 的 `name` 一致
- [x] 默认分支为 `main`
- [x] 有非 Draft / 非 Pre-release 的 Latest Release(`v0.1.0`),附件含 `package.zip`
- [x] `package.zip` 包根含 `plugin.json`、`index.js`、`icon.png`、`preview.png`、`README.md`
- [x] `icon.png` 160×160(7.2KB < 20KB)、`preview.png` 1024×768(24.2KB < 200KB)
- [x] `plugin.json` 字段合规:`name`/`author`/`url`/`version`/`minAppVersion`/`backends`/`frontends`/`displayName`/`description`/`readme`/`icon`/`i18n`/`keywords`
- [x] `url` 与仓库地址一致,`version` 为合法 semver(`0.1.0`,无 `v` 前缀)
- [x] `package.zip` 内条目路径均为正斜杠 `/`
- [x] 无未知字段、无 `theme.js`