### PR TITLE
Add macmullanjed-cell/siyuan-plugin-wordflow

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -439,3 +439,4 @@ Husense6/oh-my-siyuan
 Glaube-TY/siyuan-gesture-flow
 HibernalGlow/siyuan-damophus
 maoruibin/siyuan-inbox-sync
+macmullanjed-cell/siyuan-plugin-wordflow


### PR DESCRIPTION
Add `macmullanjed-cell/siyuan-plugin-wordflow` to the SiYuan plugin bazaar.

- Latest release: `v0.6.0`
- Release asset: `package.zip`
- Plugin name: `siyuan-plugin-wordflow`
- Display name: `SiWords`
- Supported frontend/backend: Windows desktop
- Minimum SiYuan version: `3.7.0`

The plugin repository includes English and Simplified Chinese documentation, privacy notes, license information, automated tests, and original icon/preview assets.