### PR TITLE
Add moonejue/siyuan-moon-ai

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -446,3 +446,4 @@ maoruibin/siyuan-inbox-sync
 macmullanjed-cell/siyuan-plugin-wordflow
 Solathis/siyuan-recallgen
 kx1356/siyuan-flashcard-zy
+moonejue/siyuan-moon-ai


### PR DESCRIPTION
## Plugin

- Repository: https://github.com/moonejue/siyuan-moon-ai
- Release: https://github.com/moonejue/siyuan-moon-ai/releases/tag/v1.4.0
- Version: `v1.4.0`

## Checklist

- [x] The repository is public and contains the complete source code.
- [x] An MIT `LICENSE` file is included.
- [x] The latest release contains `package.zip` and all required marketplace files.
- [x] This package does not involve infringing content or fonts/assets without commercial-use authorization.
- [x] This package is open source; no private source repository access is required.

确认：插件公开开源，包含完整源码与 MIT 许可证；不涉及侵权内容，也未使用无商用授权的字体或素材。
