### PR TITLE
Add moonejue/siyuan-moon-export

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -223,6 +223,8 @@ silent1189/siyuan-imageConverter
 Asianfleet/siyuan-plugin-aether
 Misuzu2027/syplugin-outlink-search
 Achuan-2/siyuan-plugin-doctree-focus
+moonejue/siyuan-moon-export
+
 mcwz/showtime-siyuan
 xstarling/sy-git-sync-plugin
 massivebox/siyuan-jsdraw-plugin

--- a/plugins.txt
+++ b/plugins.txt
@@ -446,3 +446,4 @@ maoruibin/siyuan-inbox-sync
 macmullanjed-cell/siyuan-plugin-wordflow
 Solathis/siyuan-recallgen
 kx1356/siyuan-flashcard-zy
+moonejue/siyuan-moon-ai

--- a/plugins.txt
+++ b/plugins.txt
@@ -223,8 +223,6 @@ silent1189/siyuan-imageConverter
 Asianfleet/siyuan-plugin-aether
 Misuzu2027/syplugin-outlink-search
 Achuan-2/siyuan-plugin-doctree-focus
-moonejue/siyuan-moon-export
-
 mcwz/showtime-siyuan
 xstarling/sy-git-sync-plugin
 massivebox/siyuan-jsdraw-plugin
@@ -449,3 +447,4 @@ macmullanjed-cell/siyuan-plugin-wordflow
 Solathis/siyuan-recallgen
 2zzw/siyuan-plugin-viewall
 kx1356/siyuan-flashcard-zy
+moonejue/siyuan-moon-export


### PR DESCRIPTION
## Plugin
- Repository: https://github.com/moonejue/siyuan-moon-export
- Release: https://github.com/moonejue/siyuan-moon-export/releases/tag/v1.0.2
- Version: v1.0.2

## Checklist
- [x] The repository is public and contains the complete source code.
- [x] An MIT LICENSE file is included.
- [x] The latest release contains package.zip and all required marketplace files.
- [x] This package does not involve infringing content or fonts/assets without commercial-use authorization.
- [x] This package is open source; no private source repository access is required.

确认：插件公开开源，包含完整源码与 MIT 许可证；不涉及侵权内容，也未使用无商用授权的字体或素材。