### PR TITLE
Add zhangzhishi1/siyuan-plugin-book-manager

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -452,3 +452,4 @@ famotime/siyuan-api-switch
 mixyoung/siyuanmaster
 Summer-Stark/siyuan-plugin-quick-access
 YOGEMOW/siyuan-plugin-text-encrypt
+zhangzhishi1/siyuan-plugin-book-manager


### PR DESCRIPTION
Add `zhangzhishi1/siyuan-plugin-book-manager` to the plugin marketplace.

- Latest release: v0.1.0
- Release asset: package.zip
- Minimum SiYuan version: 3.7.0