### PR TITLE
Add eonewg/siyuan-latex-suite

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -453,3 +453,4 @@ mixyoung/siyuanmaster
 Summer-Stark/siyuan-plugin-quick-access
 YOGEMOW/siyuan-plugin-text-encrypt
 zhangzhishi1/siyuan-plugin-book-manager
+eonewg/siyuan-latex-suite


### PR DESCRIPTION
Add **Latex Suite**, a LaTeX formula typing enhancement plugin for SiYuan.

- Repository: https://github.com/eonewg/siyuan-latex-suite
- Latest release: https://github.com/eonewg/siyuan-latex-suite/releases/tag/v0.2.10
- Package type: plugin