### PR TITLE
Add YanyingWei1997/siyuan-plugin-ying-kami-markdown

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -455,3 +455,4 @@ YOGEMOW/siyuan-plugin-text-encrypt
 zhangzhishi1/siyuan-plugin-book-manager
 eonewg/siyuan-latex-suite
 zhangzhishi1/picture-video-manager
+YanyingWei1997/siyuan-plugin-ying-kami-markdown


### PR DESCRIPTION
## Package

- Repository: https://github.com/YanyingWei1997/siyuan-plugin-ying-kami-markdown
- Latest release: https://github.com/YanyingWei1997/siyuan-plugin-ying-kami-markdown/releases/tag/v0.1.10
- Type: SiYuan plugin

## Summary

Chinese-first Markdown styling with LXGW WenKai, consistent blue headings, white paper, capsule tags, and an Esther-inspired macOS code panel. The release includes a validated `package.zip`.