### PR TITLE
Add sihan-bzwj/siyuan-paste-fixer

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -457,3 +457,4 @@ eonewg/siyuan-latex-suite
 zhangzhishi1/picture-video-manager
 YanyingWei1997/siyuan-plugin-ying-kami-markdown
 zhangzhishi1/siyuan-money-manager
+sihan-bzwj/siyuan-paste-fixer


### PR DESCRIPTION
在 plugins.txt 中新增插件 sihan-bzwj/siyuan-paste-fixer（粘贴公式修复）。

## 插件简介

粘贴时自动修复 AI 聊天文本中的破损 LaTeX（[ ] 定界符、*{} 下标丢失、矩阵反斜杠丢失、==== 碎片行、括号行内公式、Markdown 转义），并把网页 MathML / MathJax / KaTeX 公式转换为可渲染公式。块级公式以思源内部格式插入。另有选中文本右键手动转换。

- 仓库：https://github.com/sihan-bzwj/siyuan-paste-fixer
- Release：v0.1.1（含 package.zip，已通过自动化检查）
- 遵循 plugin-sample 规范，MIT 许可证

感谢审核！