### PR TITLE
Add yakoye/siyuan-drawnix-mind

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -459,3 +459,4 @@ YanyingWei1997/siyuan-plugin-ying-kami-markdown
 zhangzhishi1/siyuan-money-manager
 sihan-bzwj/siyuan-paste-fixer
 MianJu28/siyuan-rin-publisher
+yakoye/siyuan-drawnix-mind


### PR DESCRIPTION
### 确认 / Confirmation

- [x] 不涉及侵权内容或无商用授权字体。 / No infringing content or unlicensed commercial fonts are included.
- [x] 公开插件仓库与 Release 仅包含运行时分发文件和 `package.zip`，不包含 TypeScript 源码、source map、`node_modules` 或开发配置。 / The public plugin repository and Release contain runtime distribution files only.
- [x] 本插件按闭源方式分发；为遵守作者“不泄露源代码”的要求，目前未公开源码，也未创建或授权私有源码审核仓库。若审核必须，请维护者在 PR 中说明，作者将另行确认。 / This plugin is distributed as closed source. No source review repository has been shared yet; maintainers may request it in this PR if required.

插件仓库 / Plugin repository: https://github.com/yakoye/siyuan-drawnix-mind

Release: https://github.com/yakoye/siyuan-drawnix-mind/releases/tag/v0.1.26