### PR TITLE
Add FountainChan/siyuan-hexo-send

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -460,3 +460,4 @@ zhangzhishi1/siyuan-money-manager
 sihan-bzwj/siyuan-paste-fixer
 MianJu28/siyuan-rin-publisher
 yakoye/siyuan-drawnix-mind
+FountainChan/siyuan-hexo-send


### PR DESCRIPTION
## Plugin: siyuan-hexo-send

把思源笔记文档预发布到本地 Hexo 仓库的桌面插件。

- **Repo**: https://github.com/FountainChan/siyuan-hexo-send
- **Release**: https://github.com/FountainChan/siyuan-hexo-send/releases/tag/v1.0.0
- **描述**: 从思源文档树/当前文档预发布到本地 Hexo 仓库，图片自动整理、两阶段 Hexo 校验、精确暂存并创建单个本地 commit，Push 需再次确认；含已提交管理。

已在 plugins.txt 添加 `FountainChan/siyuan-hexo-send`。