### PR TITLE
Add MDfox-ChaosZone/siyuan-font-studio

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -464,3 +464,4 @@ yakoye/siyuan-drawnix-mind
 FountainChan/siyuan-hexo-send
 muweisan/siyuan-plugin-cursor-focus
 CChartreux/SiYuan-Smiles
+MDfox-ChaosZone/siyuan-font-studio


### PR DESCRIPTION
请确认以下信息：

1. 不涉及侵权内容，例如无商用授权的字体。
   - 已确认：插件安装包不捆绑任何第三方字体或示例字体预设，仅提供用户自行导入和管理字体的功能。
2. 本插件为开源项目，完整源代码位于插件仓库。

Please confirm the following information:

1. Does not involve infringing content, such as fonts without a commercial-use license.
   - Confirmed: the plugin package does not bundle third-party fonts or example font presets. It only lets users import and manage their own fonts.
2. This plugin is open source, and its complete source code is available in the plugin repository.

Plugin repository: https://github.com/MDfox-ChaosZone/siyuan-font-studio
Latest Release: https://github.com/MDfox-ChaosZone/siyuan-font-studio/releases/tag/v0.1.0