### PR TITLE
Deprecate TCOTC/siyuan-plugin-hsr-mdzz2048-fork

### DIFF
--- a/deprecated.json
+++ b/deprecated.json
@@ -1,5 +1,13 @@
 {
-  "plugins": {},
+  "plugins": {
+    "TCOTC/siyuan-plugin-hsr-mdzz2048-fork": {
+      "reason": {
+        "default": "Superseded by highlight-search",
+        "zh-CN": "请改用 highlight-search"
+      },
+      "alternatives": ["TCOTC/highlight-search"]
+    }
+  },
   "themes": {},
   "icons": {},
   "templates": {},

--- a/deprecated.json
+++ b/deprecated.json
@@ -2,8 +2,8 @@
   "plugins": {
     "TCOTC/siyuan-plugin-hsr-mdzz2048-fork": {
       "reason": {
-        "default": "Superseded by highlight-search",
-        "zh-CN": "请改用 highlight-search"
+        "default": "Please switch to the brand-new remake edition plugin highlight-search",
+        "zh-CN": "请改用全新重制版插件 highlight-search"
       },
       "alternatives": ["TCOTC/highlight-search"]
     }


### PR DESCRIPTION
弃用 [`TCOTC/siyuan-plugin-hsr-mdzz2048-fork`](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork)，请改用全新重制版插件 [`TCOTC/highlight-search`](https://github.com/TCOTC/highlight-search)。

Deprecate [`TCOTC/siyuan-plugin-hsr-mdzz2048-fork`](https://github.com/TCOTC/siyuan-plugin-hsr-mdzz2048-fork). Please switch to the brand-new remake edition [`TCOTC/highlight-search`](https://github.com/TCOTC/highlight-search).
