### PR TITLE
TEST: mix deprecated.json with plugins.txt

### DIFF
--- a/deprecated.json
+++ b/deprecated.json
@@ -1,5 +1,13 @@
 {
-  "plugins": {},
+  "plugins": {
+    "TCOTC/siyuan-plugin-hsr-mdzz2048-fork": {
+      "reason": {
+        "default": "Superseded by highlight-search",
+        "zh-CN": "请改用 highlight-search"
+      },
+      "alternatives": ["TCOTC/highlight-search"]
+    }
+  },
   "themes": {},
   "icons": {},
   "templates": {},

--- a/plugins.txt
+++ b/plugins.txt
@@ -144,6 +144,7 @@ TCOTC/siyuan-plugin-openmoji-emoji
 TCOTC/siyuan-ttf-HarmonyOS_Sans_SC-and-Twemoji
 TCOTC/siyuan-ttf-LXGWWenKaiGB-and-Twemoji
 TCOTC/siyuan-plugin-hsr-mdzz2048-fork
+
 TCOTC/snippets
 TCOTC/move-doc
 TCOTC/select-opened-doc


### PR DESCRIPTION
## 测试目的

本 PR **仅用于测试** 弃用工作流的混改拦截，**请勿合并**。

- 同时修改 `deprecated.json` 与 `plugins.txt`（在列表中插入空行）

## 预期

- FlowError：弃用注册表必须独立 PR，只能改 `deprecated.json`
- 不跑包检查 / 弃用结构校验
- 标题保持本测试标题，不会改成 `Deprecate ...`
