### PR TITLE
Deprecate TCOTC/siyuan-plugin-hsr-mdzz2048-fork

### DIFF
--- a/deprecated.json
+++ b/deprecated.json
@@ -1,5 +1,13 @@
 {
-  "plugins": {},
+  "plugins": {
+    "TCOTC/siyuan-plugin-hsr-mdzz2048-fork": {
+      "reason": {
+        "default": "Superseded by highlight-search",
+        "zh-CN": "请改用 highlight-search"
+      },
+      "alternatives": ["TCOTC/not-a-listed-plugin"]
+    }
+  },
   "themes": {},
   "icons": {},
   "templates": {},


### PR DESCRIPTION
## 测试目的

本 PR **仅用于测试** 弃用替代包引用校验，**请勿合并**。

- 只修改 `deprecated.json`
- 替代品写成未上架的 `TCOTC/not-a-listed-plugin`

## 预期

- 有有效弃用变更，标题可改为 `Deprecate TCOTC/siyuan-plugin-hsr-mdzz2048-fork`
- 校验失败：替代包不在同类型列表中
- `ci-failed`
