### PR TITLE
Deprecate TCOTC/siyuan-plugin-hsr-mdzz2048-fork

### DIFF
--- a/deprecated.json
+++ b/deprecated.json
@@ -1,5 +1,12 @@
 {
-  "plugins": {},
+  "plugins": {
+    "TCOTC/siyuan-plugin-hsr-mdzz2048-fork": {
+      "reason": {
+        "zh-CN": "请改用 highlight-search"
+      },
+      "alternatives": ["TCOTC/highlight-search"]
+    }
+  },
   "themes": {},
   "icons": {},
   "templates": {},


### PR DESCRIPTION
## 测试目的

本 PR **仅用于测试** 弃用原因 locale 校验，**请勿合并**。

- 只修改 `deprecated.json`
- `reason` 只有 `zh-CN`，没有 `default`

## 预期

- 有有效弃用变更，标题可改为 `Deprecate TCOTC/siyuan-plugin-hsr-mdzz2048-fork`
- 校验失败：包含本地化原因时必须提供 `default`
- `ci-failed`
