### PR TITLE
Add verygoodwu/siyuan-cloud-document-suite

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -472,3 +472,4 @@ leexyy/siyuan-book-switch
 famotime/siyuan-backlink-manager
 chengslog/siyuan-things
 leafs11/siyuan-leafs11
+verygoodwu/siyuan-cloud-document-suite


### PR DESCRIPTION
Add **Cloud Document Suite / 云文档套件** to the SiYuan community bazaar.

Repository: https://github.com/verygoodwu/siyuan-cloud-document-suite
Latest release: https://github.com/verygoodwu/siyuan-cloud-document-suite/releases/tag/v1.4.0

The plugin supports document-tree drag-and-drop import, PDF and Word preview, editable multi-sheet Excel workbooks, and editable FreeMind mind maps on SiYuan Desktop for Windows.