### PR TITLE
add siyuan-dxf-editor plugin and widget

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -473,3 +473,4 @@ famotime/siyuan-backlink-manager
 chengslog/siyuan-things
 leafs11/siyuan-leafs11
 verygoodwu/siyuan-cloud-document-suite
+1577967449/siyuan-dxf-editor

--- a/widgets.txt
+++ b/widgets.txt
@@ -51,3 +51,4 @@ TCOTC/inline-elements
 xiaoduo/sy-widget-show-diff
 golddogfish/siyuan-gantt
 Husense6/siyuan-gantt-widget
+1577967449/siyuan-dxf-editor-widget


### PR DESCRIPTION
## 新增 siyuan-dxf-editor（插件）与 siyuan-dxf-editor-widget（挂件）

思源笔记 DXF/DWG 在线预览工具，基于 Canvas2D 渲染器，SHX 字体默认走系统字体回退（Tahoma / 宋体），已剔除非商用 Autodesk SHX 字体，符合集市规范。

- 插件仓库：https://github.com/1577967449/siyuan-dxf-editor
- 挂件仓库：https://github.com/1577967449/siyuan-dxf-editor-widget
- 两仓库均已发布 v1.0.26 Release（含 package.zip，经 PR Check 必填文件齐全）

提示：DXF 需为无自定义对象的标准格式；DWG 预览建议参考 README 中的 @x-viewer 方案。