### PR TITLE
Add 1577967449/siyuan-dxf-editor

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -473,3 +473,4 @@ famotime/siyuan-backlink-manager
 chengslog/siyuan-things
 leafs11/siyuan-leafs11
 verygoodwu/siyuan-cloud-document-suite
+1577967449/siyuan-dxf-editor


### PR DESCRIPTION
新增思源笔记 DXF/DWG 在线预览插件（Canvas2D 渲染器，SHX 字体默认走系统字体回退，已剔除非商用 Autodesk SHX 字体）。
仓库：https://github.com/1577967449/siyuan-dxf-editor
已发布 v1.0.26 Release（含 package.zip，经 PR Check 必填文件齐全）。
DXF 需为无自定义对象的标准格式。