### PR TITLE
Add widget 1577967449/siyuan-dxf-editor-widget

### DIFF
--- a/widgets.txt
+++ b/widgets.txt
@@ -51,3 +51,4 @@ TCOTC/inline-elements
 xiaoduo/sy-widget-show-diff
 golddogfish/siyuan-gantt
 Husense6/siyuan-gantt-widget
+1577967449/siyuan-dxf-editor-widget


### PR DESCRIPTION
新增思源笔记 DXF/DWG 在线预览挂件（Canvas2D 渲染器，SHX 字体默认走系统字体回退，已剔除非商用 Autodesk SHX 字体）。
仓库：https://github.com/1577967449/siyuan-dxf-editor-widget
已发布 v1.0.26 Release（含 package.zip，经 PR Check 必填文件齐全）。
建议与 siyuan-dxf-editor 插件配套安装。