### PR TITLE
Add hong602/com.sunazure.backtotop

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -475,3 +475,4 @@ chengslog/siyuan-things
 leafs11/siyuan-leafs11
 verygoodwu/siyuan-cloud-document-suite
 LongDarkroom/siyuan-plugin-reword
+hong602/com.sunazure.backtotop

--- a/plugins.txt
+++ b/plugins.txt
@@ -475,4 +475,6 @@ chengslog/siyuan-things
 leafs11/siyuan-leafs11
 verygoodwu/siyuan-cloud-document-suite
 LongDarkroom/siyuan-plugin-reword
+xushuo97/diary-calendar
+CongSec/siyuan-plugin-meiday
 hong602/com.sunazure.backtotop


### PR DESCRIPTION
### 新增插件
- 仓库：https://github.com/hong602/com.sunazure.backtotop
- Release：https://github.com/hong602/com.sunazure.backtotop/releases/tag/1.0.0
- 附件 package.zip：https://github.com/hong602/com.sunazure.backtotop/releases/download/1.0.0/package.zip
- 插件名 / plugin id：`com.sunazure.backtotop`（中文名：回到顶部 / 英文名：Back to Top）
- 版本：`1.0.0`
- 作者：蔚蓝升阳（GitHub @hong602）
- 描述：在编辑器右下角添加网页风格的回到顶部悬浮按钮，向下滚动超过阈值后淡入显示，点击则平滑滚回当前文档顶部。
- minAppVersion / 思源最低版本：`2.8.0`