### PR TITLE
Add xushuo97/diary-calendar

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -475,3 +475,4 @@ chengslog/siyuan-things
 leafs11/siyuan-leafs11
 verygoodwu/siyuan-cloud-document-suite
 LongDarkroom/siyuan-plugin-reword
+xushuo97/diary-calendar


### PR DESCRIPTION
Add [diary-calendar](https://github.com/xushuo97/diary-calendar) plugin to the bazaar.

A SiYuan plugin that embeds a monthly calendar into notes, allowing in-cell diary writing (like OneNote). Diaries are stored as real notes (searchable, backlink-able, appear in the graph view).

Features:
- Month / week dual view, click a date cell to write directly
- WYSIWYG: diary content shows directly in the cell
- Weekly notes & monthly summaries
- Auto light/dark theme adaptation
- Truly transparent background
- Resizable height (drag handle at bottom-right)

Repository: https://github.com/xushuo97/diary-calendar
Release: https://github.com/xushuo97/diary-calendar/releases/tag/v0.1.7