### PR TITLE
Add fu1fan/siyuan-paper-manager

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -478,3 +478,4 @@ LongDarkroom/siyuan-plugin-reword
 xushuo97/diary-calendar
 CongSec/siyuan-plugin-meiday
 hong602/com.sunazure.backtotop
+fu1fan/siyuan-paper-manager


### PR DESCRIPTION
新增插件：siyuan-paper-manager（论文管理）

- 仓库：https://github.com/fu1fan/siyuan-paper-manager
- Release：https://github.com/fu1fan/siyuan-paper-manager/releases/tag/v0.4.0
- 功能：以思源原生数据库管理论文文献库，接收 Zotero Connector 文献与附件，编辑论文元数据，导出引用（GB/T 7714—2015 / APA 7 / IEEE / BibTeX / BibLaTeX / Typst Hayagriva），并可调用本地 pdf2zh 生成翻译版本。