### PR TITLE
Add fengle992/siyuan-zotflow

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -486,3 +486,4 @@ vejomikakero/siyuan-worklog-calendar
 haoge321/siyuan-plugin-weather
 IAliceBobI/sy-recite-plugin
 getcodeQi/siyuan-plugin-advanced-code
+fengle992/siyuan-zotflow


### PR DESCRIPTION
## Description

Adds a new plugin to the SiYuan community bazaar.

- **Plugin**: [ZotFlow Sync (siyuan-zotflow)](https://github.com/fengle992/siyuan-zotflow)
- **Function**: Incrementally syncs Obsidian ZotFlow literature notes (Zotero annotations) into SiYuan. Unchanged blocks keep their block IDs, so flashcards, block references and backlinks remain valid across syncs. Also supports full overwrite sync and YAML frontmatter stripping.

## Checklist

- [x] Latest Release published with `package.zip` attachment: [v0.5.0](https://github.com/fengle992/siyuan-zotflow/releases/tag/v0.5.0)
- [x] `plugin.json` metadata complete (name / author / url / version / minAppVersion / displayName / description / readme)
- [x] Icon 160×160 (22 KB) and preview 1024×768 (424 KB) within bazaar limits
- [x] License: AGPL-3.0-only (derived from [ZotFlow](https://github.com/duanxianpi/zotflow), with attribution)