### PR TITLE
Add ai68298100/siyuan-speed-switch

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -487,3 +487,4 @@ haoge321/siyuan-plugin-weather
 IAliceBobI/sy-recite-plugin
 getcodeQi/siyuan-plugin-advanced-code
 fengle992/siyuan-zotflow
+ai68298100/siyuan-speed-switch


### PR DESCRIPTION
### 插件 / Plugin

[`ai68298100/siyuan-speed-switch`](https://github.com/ai68298100/siyuan-speed-switch)

**小驴速切（LvSpeed Switch）** — 像 Windows Alt+Tab 一样以实时缩略图快速切换已打开的页签；支持收藏分组、全库文档搜索、面板速达与侧边栏常驻模式（分栏布局完全支持）。

**LvSpeed Switch** — Flip through open tabs like Windows Alt+Tab with live thumbnails; grouped favorites, workspace-wide document search, dock-panel shortcuts and a persistent sidebar mode (split windows fully supported).

- Latest Release: [v0.6.0](https://github.com/ai68298100/siyuan-speed-switch/releases/tag/v0.6.0)（含 `package.zip`）
- 仓库根目录包含集市要求的必要文件：`README.md` / `plugin.json` / `index.js` / `icon.png` / `preview.png`
- 我是该插件的作者，将长期维护。
- I'm the author of this plugin and will keep maintaining it.
