### PR TITLE
Add BryceWG/siyuan-upload-pages

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -488,3 +488,4 @@ IAliceBobI/sy-recite-plugin
 getcodeQi/siyuan-plugin-advanced-code
 fengle992/siyuan-zotflow
 ai68298100/siyuan-speed-switch
+BryceWG/siyuan-upload-pages


### PR DESCRIPTION
PaperKite (纸鸢): publishes a SiYuan document as a self-contained static page to Cloudflare Pages or Vercel.

Repo: https://github.com/BryceWG/siyuan-upload-pages
Latest release: v0.1.0 with package.zip