### PR TITLE
Add wmy2981/ref-crumbs-siyuan

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -489,3 +489,4 @@ getcodeQi/siyuan-plugin-advanced-code
 fengle992/siyuan-zotflow
 ai68298100/siyuan-speed-switch
 BryceWG/siyuan-upload-pages
+wmy2981/ref-crumbs-siyuan


### PR DESCRIPTION
- 类型：插件
- 仓库：https://github.com/wmy2981/ref-crumbs-siyuan
- Released tag: v0.1.0（含 package.zip 资产）
- 说明：思源笔记插件 —— 在块引用（((）搜索列表中显示每个块的标题层级面包屑（h2-h6），纯前端实现，基于官方 API /api/block/getBlockBreadcrumb