### PR TITLE
Add leofang230316-prog/siyuan-plugin-weread-sync

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -492,3 +492,4 @@ ai68298100/siyuan-speed-switch
 BryceWG/siyuan-upload-pages
 wmy2981/ref-crumbs-siyuan
 fyuanace/cursorart-tools
+leofang230316-prog/siyuan-plugin-weread-sync


### PR DESCRIPTION
### 添加插件 / Add Plugin

**插件 / Package**: [leofang230316-prog/siyuan-plugin-weread-sync](https://github.com/leofang230316-prog/siyuan-plugin-weread-sync)

**说明 / Description**:

同步微信读书的书籍、划线与想法到思源笔记；增量追加，不覆盖用户已有编辑；支持 `/weread` 斜杠命令插入笔记引用。

Sync WeRead books, highlights and notes into SiYuan incrementally without overwriting user edits; supports inserting note references via the `/weread` slash command.

**检查清单 / Checklist**:

- [x] 仓库公开，且仓库名与 `plugin.json` 的 `name` 一致
- [x] 已发布 Latest Release（v1.2.1），并附带 `package.zip`
- [x] `plugin.json` 含 name / author / url / version / minAppVersion / displayName / description / readme 等必需字段
- [x] 已包含 `README.md`、`LICENSE`（MIT）、`icon.png`、`preview.png`

cc @leofang230316-prog