### PR TITLE
Add Lizhen0628/siyuan-plugin-pichost

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -493,3 +493,4 @@ BryceWG/siyuan-upload-pages
 wmy2981/ref-crumbs-siyuan
 fyuanace/cursorart-tools
 leofang230316-prog/siyuan-plugin-weread-sync
+Lizhen0628/siyuan-plugin-pichost


### PR DESCRIPTION
Add a new plugin package.

- **Repo**: https://github.com/Lizhen0628/siyuan-plugin-pichost
- **Name**: `siyuan-plugin-pichost` (same as repo name)
- **Version**: `0.1.0` ([Release v0.1.0](https://github.com/Lizhen0628/siyuan-plugin-pichost/releases/tag/v0.1.0) with `package.zip` attached)
- **Description**: Upload document images to a self-hosted PicHost server and manage them (list / search / copy links / delete). SiYuan plugin that uploads editor/document images to a PicHost image host and rewrites references to public URLs, with a management panel for listing, search, copy links and deletion.
- **i18n**: en / zh-CN READMEs and UI strings
- **Marketplace metadata**: `plugin.json` validated against template spec (`url` matches repo, semver version, icon 160x160 < 64 KiB, preview 1024x768 < 512 KiB)