### PR TITLE
Add alexremi666/siyuan-clock

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -496,3 +496,4 @@ fyuanace/cursorart-tools
 leofang230316-prog/siyuan-plugin-weread-sync
 Lizhen0628/siyuan-plugin-pichost
 Lizhen0628/siyuan-ai-agent
+alexremi666/siyuan-clock


### PR DESCRIPTION
Add plugin repo `alexremi666/siyuan-clock`.

SiYuan Clock Plugin：以标签页（桌面端）/ Dock + 全屏弹窗（移动端）显示大号当前时间、日期与星期、农历（干支生肖），全端兼容，配色跟随思源主题。本项目由 AI 生成。