### PR TITLE
Add wmy2981/ai-title-siyuan

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -499,3 +499,4 @@ leofang230316-prog/siyuan-plugin-weread-sync
 Lizhen0628/siyuan-plugin-pichost
 Lizhen0628/siyuan-ai-agent
 alexremi666/siyuan-clock
+wmy2981/ai-title-siyuan


### PR DESCRIPTION
Add `wmy2981/ai-title-siyuan` to `plugins.txt`.

**AI Title** — 用任意 OpenAI 兼容的 chat completions 接口为思源笔记生成标题。

- 仓库：https://github.com/wmy2981/ai-title-siyuan
- Release：https://github.com/wmy2981/ai-title-siyuan/releases/tag/v0.1.0
- `minAppVersion`：3.8.3
- 许可：MIT

---

请确认以下信息：

1. 不涉及侵权内容，例如无商用授权的字体
   —— 确认。界面只使用思源内置图标集与系统字体栈，未打包任何第三方字体或图片素材；插件图标系自行绘制，仓库以 MIT 授权。

2. 如果集市包是闭源的，请创建一个包含集市包完整源代码的私有 GitHub 仓库，并授予 @TCOTC、@88250 和 @Vanessa219 仓库访问权限，以便我们完成审核
   —— 不适用。本包开源（MIT），完整源码即在上方公开仓库中。

Please confirm the following information:

1. Does not involve infringing content, such as fonts without a commercial-use license
   —— Confirmed. The UI uses only SiYuan's built-in icon set and system font stacks; no third-party fonts or image assets are bundled. The plugin icon is drawn in-house, and the repository is MIT licensed.

2. If the marketplace package is closed-source, please create a private GitHub repository containing the complete source code...
   —— Not applicable. This package is open source (MIT); the complete source is in the public repository linked above.
